### PR TITLE
[PKG-13411] Update to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
 
 # Unable to run tests and check imports, openai-agents is not in the main channel.
 test:
+  imports:
+    - opentelemetry.instrumentation.openai_agents
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
   run_constrained:
     - openai-agents >=0.2.7,<0.3.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,3 +50,4 @@ extra:
     - timkpaine
   skip-lints:
     - reachable_url
+    - missing_imports_or_run_test_py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,10 @@ requirements:
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
+    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
+  run_constrained:
+    - openai-agents >=0.2.7,<0.3.0
 
-# Unable to run tests and check imports, openai-agents is not in the main channel.
 test:
   imports:
     - opentelemetry.instrumentation.openai_agents

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,8 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
+  run_constrained:
+    - openai-agents >=0.6.9
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
-  run_constrained:
-    - openai-agents >=0.2.7,<0.3.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "opentelemetry-instrumentation-openai-agents" %}
-{% set version = "0.49.6" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,26 +7,24 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 994a9cb0a334668b7144812915626016596c374ca52828fa25c58938f4f451c4
+  sha256: 19f620953591b84ee3b67bdfc898bb5fe14283a5197fa1aea28ee8b0f8d37164
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<39]
+  skip: true  # [py<310]
 
 requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.38.0,<2.0.0
     - opentelemetry-instrumentation >=0.59b0
     - opentelemetry-semantic-conventions >=0.59b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5
-  run_constrained:
-    - openai-agents >=0.2.7,<0.3.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
 
 # Unable to run tests and check imports, openai-agents is not in the main channel.
 test:
@@ -51,5 +49,4 @@ extra:
   recipe-maintainers:
     - timkpaine
   skip-lints:
-    - invalid_url
-    - missing_imports_or_run_test_py
+    - reachable_url


### PR DESCRIPTION
opentelemetry-instrumentation-openai-agents 0.57.0

**Destination channel:** defaults

### Links

- [PKG-13411]
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0/packages/opentelemetry-instrumentation-openai-agents)

### Explanation of changes:

- Adjust skip-lints
- Update build system to hatchling


[PKG-13411]: https://anaconda.atlassian.net/browse/PKG-13411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ